### PR TITLE
Add Workaround for Broken Web Requests in the Garmin SDK.

### DIFF
--- a/widget/source/Constants.mc
+++ b/widget/source/Constants.mc
@@ -6,6 +6,8 @@ import Toybox.WatchUi;
 class Constants {
     static const REFRESH_DELAY_S = 30;
 
+    static const MAX_CONCURRENT_REQUESTS = 3;
+
     (:roundScreen)
     static const DAYS_TO_SHOW = 5;
     (:semioctagonalScreen)


### PR DESCRIPTION
Add a workaround for the brokenness of `makeWebRequest()` in the Garmin SDK that causes it to 'forget' to add the context to the callback in some cases. Looks like this can be avoided when the number of in-flight web requests is limited.
Also fix a bug resulting in refreshes not happening after the first one.